### PR TITLE
Support specifying per-linter cwd as function

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -6,8 +6,11 @@
   "workspace": {
     "library": [
       "$VIMRUNTIME",
-      "${3rd}/luv/library"
+      "${3rd}/luv/library",
+      "${3rd}/busted/library",
+      "${3rd}/luassert/library",
+      "lua"
     ],
     "checkThirdParty": false
-  },
+  }
 }

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Other dedicated linters that are built-in are:
 | [salt-lint][salt-lint]                 | `saltlint`             |
 | [Selene][31]                           | `selene`               |
 | [ShellCheck][10]                       | `shellcheck`           |
+| [Snakemake][snakemake]                 | `snakemake`            |
 | [snyk][snyk]                           | `snyk_iac`             |
 | [Solhint][solhint]                     | `solhint`              |
 | [Spectral][spectral]                   | `spectral`             |
@@ -545,6 +546,7 @@ busted tests/
 [write-good]: https://github.com/btford/write-good
 [dotenv-linter]: https://dotenv-linter.github.io/
 [puppet-lint]: https://github.com/puppetlabs/puppet-lint
+[snakemake]: https://snakemake.github.io
 [snyk]: https://github.com/snyk/cli
 [spectral]: https://github.com/stoplightio/spectral
 [gitlint]: https://github.com/jorisroovers/gitlint

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Other dedicated linters that are built-in are:
 | [ktlint][ktlint]                       | `ktlint`               |
 | [lacheck][lacheck]                     | `lacheck`              |
 | [Languagetool][5]                      | `languagetool`         |
+| [luac][luac]                           | `luac`                 |
 | [luacheck][19]                         | `luacheck`             |
 | [markdownlint][26]                     | `markdownlint`         |
 | [markdownlint-cli2][markdownlint-cli2] | `markdownlint-cli2`    |
@@ -495,6 +496,7 @@ busted tests/
 [phpstan]: https://phpstan.org/
 [psalm]: https://psalm.dev/
 [lacheck]: https://www.ctan.org/tex-archive/support/lacheck
+[luac]: https://www.lua.org/manual/5.1/luac.html
 [credo]: https://github.com/rrrene/credo
 [ghdl]: https://github.com/ghdl/ghdl
 [glslc]: https://github.com/google/shaderc

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Other dedicated linters that are built-in are:
 | [alex][alex]                           | `alex`                 |
 | [ameba][ameba]                         | `ameba`                |
 | [ansible-lint][ansible-lint]           | `ansible_lint`         |
+| [awk][awk]                             | `awk`                  |
 | [bandit][bandit]                       | `bandit`               |
 | [bean-check][bean-check]               | `bean_check`           |
 | [biomejs][biomejs]                     | `biomejs`              |
@@ -564,3 +565,4 @@ busted tests/
 [clippy]: https://github.com/rust-lang/rust-clippy
 [hledger]: https://hledger.org/
 [systemd-analyze]: https://man.archlinux.org/man/systemd-analyze.1
+[awk]: https://www.gnu.org/software/gawk/

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Other dedicated linters that are built-in are:
 | [statix check][33]                     | `statix`               |
 | [stylelint][29]                        | `stylelint`            |
 | [SwiftLint][swiftlint]                 | `swiftlint`            |
+| [systemd-analyze][systemd-analyze]     | `systemd-analyze`      |
 | [systemdlint][systemdlint]             | `systemdlint`          |
 | [tflint][tflint]                       | `tflint`               |
 | [tfsec][tfsec]                         | `tfsec`                |
@@ -543,3 +544,4 @@ busted tests/
 [eugene]: https://github.com/kaaveland/eugene
 [clippy]: https://github.com/rust-lang/rust-clippy
 [hledger]: https://hledger.org/
+[systemd-analyze]: https://man.archlinux.org/man/systemd-analyze.1

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Other dedicated linters that are built-in are:
 | [chktex][20]                           | `chktex`               |
 | [clang-tidy][23]                       | `clangtidy`            |
 | [clazy][30]                            | `clazy`                |
+| [clippy][clippy]                       | `clippy`               |
 | [clj-kondo][24]                        | `clj-kondo`            |
 | [cmakelint][cmakelint]                 | `cmakelint`            |
 | [codespell][18]                        | `codespell`            |
@@ -539,3 +540,4 @@ busted tests/
 [tflint]: https://github.com/terraform-linters/tflint
 [ameba]: https://github.com/crystal-ameba/ameba
 [eugene]: https://github.com/kaaveland/eugene
+[clippy]: https://github.com/rust-lang/rust-clippy

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Other dedicated linters that are built-in are:
 | [joker][joker]                         | `joker`                |
 | [jshint][jshint]                       | `jshint`               |
 | [jsonlint][jsonlint]                   | `jsonlint`             |
+| [ksh][ksh]                             | `ksh`                  |
 | [ktlint][ktlint]                       | `ktlint`               |
 | [lacheck][lacheck]                     | `lacheck`              |
 | [Languagetool][5]                      | `languagetool`         |
@@ -485,6 +486,7 @@ busted tests/
 [cmakelint]: https://github.com/cmake-lint/cmake-lint
 [rstcheck]: https://github.com/myint/rstcheck
 [rstlint]: https://github.com/twolfson/restructuredtext-lint
+[ksh]: https://github.com/ksh93/ksh
 [ktlint]: https://github.com/pinterest/ktlint
 [php]: https://www.php.net/
 [phpcs]: https://github.com/squizlabs/PHP_CodeSniffer

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Other dedicated linters that are built-in are:
 | [woke][woke]                           | `woke`                 |
 | [write-good][write-good]               | `write_good`           |
 | [yamllint][yamllint]                   | `yamllint`             |
+| [yq][yq]                               | `yq`                   |
 | [zsh][zsh]                             | `zsh`                  |
 
 ## Custom Linters
@@ -566,3 +567,4 @@ busted tests/
 [hledger]: https://hledger.org/
 [systemd-analyze]: https://man.archlinux.org/man/systemd-analyze.1
 [awk]: https://www.gnu.org/software/gawk/
+[yq]: https://mikefarah.gitbook.io/yq

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Other dedicated linters that are built-in are:
 | [glslc][glslc]                         | `glslc`                |
 | [Golangci-lint][16]                    | `golangcilint`         |
 | [hadolint][28]                         | `hadolint`             |
+| [hledger][hledger]                     | `hledger`              |
 | [hlint][32]                            | `hlint`                |
 | [htmlhint][htmlhint]                   | `htmlhint`             |
 | [HTML Tidy][12]                        | `tidy`                 |
@@ -541,3 +542,4 @@ busted tests/
 [ameba]: https://github.com/crystal-ameba/ameba
 [eugene]: https://github.com/kaaveland/eugene
 [clippy]: https://github.com/rust-lang/rust-clippy
+[hledger]: https://hledger.org/

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Configure the linters you want to run per file type. For example:
 
 ```lua
 require('lint').linters_by_ft = {
-  markdown = {'vale',}
+  markdown = {'vale'},
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Other dedicated linters that are built-in are:
 | [erb-lint][erb-lint]                   | `erb_lint`             |
 | [ESLint][25]                           | `eslint`               |
 | [eslint_d][37]                         | `eslint_d`             |
+| [eugene][eugene]                       | `eugene`               |
 | [fennel][fennel]                       | `fennel`               |
 | [fish][fish]                           | `fish`                 |
 | [Flake8][13]                           | `flake8`               |
@@ -537,3 +538,4 @@ busted tests/
 [swiftlint]: https://github.com/realm/SwiftLint
 [tflint]: https://github.com/terraform-linters/tflint
 [ameba]: https://github.com/crystal-ameba/ameba
+[eugene]: https://github.com/kaaveland/eugene

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Other dedicated linters that are built-in are:
 | [salt-lint][salt-lint]                 | `saltlint`             |
 | [Selene][31]                           | `selene`               |
 | [ShellCheck][10]                       | `shellcheck`           |
+| [slang][slang]                         | `slang`                |
 | [Snakemake][snakemake]                 | `snakemake`            |
 | [snyk][snyk]                           | `snyk_iac`             |
 | [Solhint][solhint]                     | `solhint`              |
@@ -576,3 +577,4 @@ busted tests/
 [systemd-analyze]: https://man.archlinux.org/man/systemd-analyze.1
 [awk]: https://www.gnu.org/software/gawk/
 [yq]: https://mikefarah.gitbook.io/yq
+[slang]: https://github.com/MikePopoloski/slang

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Other dedicated linters that are built-in are:
 | [ansible-lint][ansible-lint]           | `ansible_lint`         |
 | [awk][awk]                             | `awk`                  |
 | [bandit][bandit]                       | `bandit`               |
+| [bash][bash]                           | `bash`                 |
 | [bean-check][bean-check]               | `bean_check`           |
 | [biomejs][biomejs]                     | `biomejs`              |
 | [blocklint][blocklint]                 | `blocklint`            |
@@ -509,6 +510,7 @@ busted tests/
 [ruff]: https://github.com/astral-sh/ruff
 [janet]: https://github.com/janet-lang/janet
 [bandit]: https://bandit.readthedocs.io/en/latest/
+[bash]: https://www.gnu.org/software/bash/
 [bean-check]: https://beancount.github.io/docs/running_beancount_and_generating_reports.html#bean-check
 [cue]: https://github.com/cue-lang/cue
 [curlylint]: https://www.curlylint.org/

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Other dedicated linters that are built-in are:
 | [StandardRB][27]                       | `standardrb`           |
 | [statix check][33]                     | `statix`               |
 | [stylelint][29]                        | `stylelint`            |
+| [svlint][svlint]                       | `svlint`               |
 | [SwiftLint][swiftlint]                 | `swiftlint`            |
 | [systemd-analyze][systemd-analyze]     | `systemd-analyze`      |
 | [systemdlint][systemdlint]             | `systemdlint`          |
@@ -577,4 +578,5 @@ busted tests/
 [systemd-analyze]: https://man.archlinux.org/man/systemd-analyze.1
 [awk]: https://www.gnu.org/software/gawk/
 [yq]: https://mikefarah.gitbook.io/yq
+[svlint]: https://github.com/dalance/svlint
 [slang]: https://github.com/MikePopoloski/slang

--- a/README.md
+++ b/README.md
@@ -277,15 +277,26 @@ The function takes two arguments: `errorformat` and `skeleton` (optional).
 
 ### from_pattern
 
+Creates a parser function from a pattern.
+
 ```lua
 parser = require('lint.parser').from_pattern(pattern, groups, severity_map, defaults, opts)
 ```
 
-The function allows to parse the linter's output using a Lua regular expression pattern.
+### pattern
 
-- pattern: The regular expression pattern applied on each line of the output
-- groups: The groups specified by the pattern
+The function allows to parse the linter's output using a pattern which can be either:
 
+- A Lua pattern. See `:help lua-patterns`.
+- A LPEG pattern object. See `:help vim.lpeg`.
+- A function (`fun(line: string):string[]`). It takes one parameter - a line
+  from the linter output and must return a string array with the matches. The
+  array should be empty if there was no match.
+
+
+### groups
+
+The groups specify the result format of the pattern.
 Available groups:
 
 - `lnum`
@@ -305,7 +316,11 @@ local pattern = '[^:]+:(%d+):(%d+):(%w+):(.+)'
 local groups = { 'lnum', 'col', 'code', 'message' }
 ```
 
-- severity: A mapping from severity codes to diagnostic codes
+The captures in the pattern correspond to the group at the same position.
+
+### severity
+
+A mapping from severity codes to diagnostic codes
 
 ``` lua
 default_severity = {
@@ -316,18 +331,22 @@ default_severity = {
 }
 ```
 
-- defaults: The defaults diagnostic values
+### defaults
+
+The defaults diagnostic values
 
 ```lua
 defaults = {["source"] = "mylint-name"}
 ```
 
-- opts: Additional options
+### opts
 
-  - `lnum_offset`: Added to `lnum`. Defaults to 0
-  - `end_lnum_offset`: Added to `end_lnum`. Defaults to 0
-  - `end_col_offset`: offset added to `end_col`. Defaults to `-1`, assuming
-    that the end-column position is exclusive.
+Additional options
+
+- `lnum_offset`: Added to `lnum`. Defaults to 0
+- `end_lnum_offset`: Added to `end_lnum`. Defaults to 0
+- `end_col_offset`: offset added to `end_col`. Defaults to `-1`, assuming
+  that the end-column position is exclusive.
 
 
 ## Customize built-in linters

--- a/doc/lint.txt
+++ b/doc/lint.txt
@@ -1,0 +1,182 @@
+==============================================================================
+Table of Contents                                                         *lint*
+
+Main nvim-lint API ······················································ |lint|
+Parsers and parse functions ······································ |lint.parser|
+
+==============================================================================
+Main nvim-lint API                                                        *lint*
+
+M.linters_by_ft                                                *M.linters_by_ft*
+    A table listing which linters to run via `try_lint`.
+    The key is the filetype. The values are a list of linter names
+
+    Example:
+
+    ```lua
+    require("lint").linters_by_ft = {
+      python = {"ruff", "mypy"}
+    }
+    ```
+
+
+    Type: ~
+        (table<string,string[]>)
+
+
+M.try_lint({names?}, {opts?})                                    *lint.try_lint*
+     Run the linters with the given names.
+     If no names are given, it runs the linters configured in `linters_by_ft`
+
+
+    Parameters: ~
+        {names?}  (string|string[])                       name of the linter
+        {opts?}   ({cwd?:string,ignore_errors?:boolean})  options
+
+
+M.get_namespace({name})                                     *lint.get_namespace*
+     Return the namespace for a given linter.
+
+     Can be used to configure diagnostics for a given linter. For example:
+
+     ```lua
+     local ns = require("lint").get_namespace("my_linter_name")
+     vim.diagnostic.config({ virtual_text = true }, ns)
+
+     ```
+
+
+    Parameters: ~
+        {name}  (string)  linter
+
+
+M.get_running({bufnr?})                                       *lint.get_running*
+     Returns the names of the running linters
+
+
+    Parameters: ~
+        {bufnr?}  (integer)  buffer for which to get the running linters. nil=all buffers
+
+    Returns: ~
+        (string[])
+
+
+M.linters                                                            *M.linters*
+    Table with the available linters
+
+    Type: ~
+        (table<string,lint.Linter|fun():lint.Linter>)
+
+
+lint.Linter                                                        *lint.Linter*
+    A Linter
+
+    Fields: ~
+        {name}              (string)
+        {cmd}               (string)                    command/executable
+        {args?}             (string|fun():string[])     command arguments
+        {stdin?}            (boolean)                   send content via stdin. Defaults to false
+        {append_fname?}     (boolean)                   Automatically add the current file name to the commands arguments.
+                                                        Only has an effect if stdin is false
+        {stream}            ("stdout"|"stderr"|"both")  result stream. Defaults to stdout
+        {ignore_exitcode?}  (boolean)                   Declares if exit code != 1 should be ignored or result in a warning. Defaults to false
+        {env?}              (table)
+        {cwd?}              (string)
+        {parser}            (lint.Parser|lint.parse)
+
+
+lint.LintProc                                                    *lint.LintProc*
+    A currently running lint process
+
+    Fields: ~
+        {bufnr}    (integer)
+        {handle}   (uv.uv_process_t)
+        {stdout}   (uv.uv_pipe_t)
+        {stderr}   (uv.uv_pipe_t)
+        {linter}   (lint.Linter)
+        {cwd}      (string)
+        {ns}       (integer)
+        {stream?}  ()
+
+
+lint.parse                                                          *lint.parse*
+    Parse function for a linter
+
+    Type: ~
+        fun(output:string,bufnr:number,linter_cwd:string):vim.Diagnostic[]
+
+
+lint.Parser                                                        *lint.Parser*
+    Internal Parser
+
+    Fields: ~
+        {on_chunk}  (fun(chunk:string))
+        {on_done}   (fun(publish:fun(diagnostics:vim.Diagnostic[]),bufnr:number,linter_cwd:string))
+
+
+lint.LintProc                                                    *lint.LintProc*
+
+
+M.lint({linter}, {opts?})                                            *lint.lint*
+     Runs the given linter.
+     This is usually not used directly but called via `try_lint`
+
+
+    Parameters: ~
+        {linter}  (lint.Linter)
+        {opts?}   ({cwd?:string,ignore_errors?:boolean})
+
+    Returns: ~
+        (lint.LintProc|nil)
+
+
+==============================================================================
+Parsers and parse functions                                        *lint.parser*
+
+M.from_errorformat({efm}, {skeleton})             *lint.parser.from_errorformat*
+    Return a parse function that uses an errorformat to parse the output.
+
+    Parameters: ~
+        {efm}       (string)                            Format following |errorformat|
+        {skeleton}  (table<string,any>|vim.Diagnostic)  default values
+
+    Returns: ~
+        (lint.parse)
+
+
+                                                      *lint.parser.from_pattern*
+M.from_pattern({pattern}, {groups}, {severity_map?}, {defaults?}, {opts?})
+    Return a parse function that parses a linter's output using a Lua or LPEG pattern.
+
+
+    Parameters: ~
+        {pattern}        (string|vim.lpeg.Pattern|fun(line:string):string[])
+        {groups}         (string[])
+        {severity_map?}  (table<string,vim.diagnostic.Severity>)
+        {defaults?}      (table)
+        {opts?}          ({col_offset?:integer,end_col_offset?:integer,lnum_offset?:integer,end_lnum_offset?:integer})
+
+    Returns: ~
+        (lint.parse)
+
+
+M.accumulate_chunks({parse})                     *lint.parser.accumulate_chunks*
+     Turn a parse function into a parser table
+
+
+    Parameters: ~
+        {parse}  (fun(output:string,bufnr:integer,cwd:string):vim.Diagnostic[])
+
+    Returns: ~
+        (lint.Parser)
+
+
+M.split({parser})                                            *lint.parser.split*
+    Split a parser into two
+
+
+    Parameters: ~
+        {parser}  (lint.Parser)  @return lint.Parser, lint.Parser
+
+
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/lint.txt
+++ b/doc/lint.txt
@@ -1,5 +1,5 @@
 ==============================================================================
-Table of Contents                                                         *lint*
+Table of Contents                                                     *lint.toc*
 
 Main nvim-lint API ······················································ |lint|
 Parsers and parse functions ······································ |lint.parser|
@@ -112,9 +112,6 @@ lint.Parser                                                        *lint.Parser*
     Fields: ~
         {on_chunk}  (fun(chunk:string))
         {on_done}   (fun(publish:fun(diagnostics:vim.Diagnostic[]),bufnr:number,linter_cwd:string))
-
-
-lint.LintProc                                                    *lint.LintProc*
 
 
 M.lint({linter}, {opts?})                                            *lint.lint*

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -357,6 +357,9 @@ function M.lint(linter, opts)
     -- pop up shortly.
     detached = not iswin
   }
+  if type(linter_opts.cwd) == 'function' then
+    linter_opts.cwd = linter_opts.cwd()
+  end
   -- prevents cmd.exe taking over the tab title
   if iswin then
     linter_opts.hide = true

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -323,6 +323,10 @@ function M.lint(linter, opts)
     -- pop up shortly.
     detached = not iswin
   }
+  -- prevents cmd.exe taking over the tab title
+  if iswin then
+    linter_opts.hide = true
+  end
   local cmd = eval_fn_or_id(linter.cmd)
   assert(cmd, 'Linter definition must have a `cmd` set: ' .. vim.inspect(linter))
   handle, pid_or_err = uv.spawn(cmd, linter_opts, function(code)

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -4,6 +4,8 @@ local notify = vim.notify_once or vim.notify
 local M = {}
 
 
+---@alias lint.parse fun(output:string, bufnr:number, linter_cwd:string):vim.Diagnostic[]
+
 ---@class lint.Parser
 ---@field on_chunk fun(chunk: string)
 ---@field on_done fun(publish: fun(diagnostics: vim.Diagnostic[]), bufnr: number, linter_cwd: string)
@@ -19,7 +21,7 @@ local M = {}
 ---@field ignore_exitcode? boolean if exit code != 1 should be ignored or result in a warning. Defaults to false
 ---@field env? table
 ---@field cwd? string
----@field parser lint.Parser|fun(output:string, bufnr:number, linter_cwd:string):vim.Diagnostic[]
+---@field parser lint.Parser|lint.parse
 
 
 ---@class lint.LintProc

--- a/lua/lint.lua
+++ b/lua/lint.lua
@@ -1,4 +1,4 @@
----@toc lint
+---@toc lint.toc
 ---
 ---@mod lint Main nvim-lint API
 
@@ -219,6 +219,7 @@ function M._resolve_linter_by_ft(ft)
 end
 
 
+---@private
 ---@class lint.LintProc
 local LintProc = {}
 local linter_proc_mt = {

--- a/lua/lint/linters/awk.lua
+++ b/lua/lint/linters/awk.lua
@@ -1,0 +1,14 @@
+local pattern = ":(%d+):.-\n*%^%s*(%S.*)"
+local groups = { "lnum", "message" }
+
+return {
+  cmd = "awk",
+  stdin = true,
+  args = { "-f-", "-L" },
+  stream = "stderr",
+  ignore_exitcode = true,
+  parser = require("lint.parser").from_pattern(pattern, groups, nil, {
+    source = "awk",
+    severity = vim.diagnostic.severity.ERROR,
+  }),
+}

--- a/lua/lint/linters/bash.lua
+++ b/lua/lint/linters/bash.lua
@@ -1,0 +1,12 @@
+return {
+  cmd = "bash",
+  stdin = true,
+  append_fname = false,
+  args = { "-n", "-s" },
+  stream = "stderr",
+  ignore_exitcode = true,
+  parser = require("lint.parser").from_errorformat("bash:\\ line\\ %l:\\ %m", {
+    source = "bash",
+    severity = vim.diagnostic.severity.ERROR,
+  }),
+}

--- a/lua/lint/linters/clippy.lua
+++ b/lua/lint/linters/clippy.lua
@@ -1,0 +1,51 @@
+local severities = {
+  note = vim.diagnostic.severity.INFO,
+  warning = vim.diagnostic.severity.WARN,
+  help = vim.diagnostic.severity.HINT,
+}
+
+local function parse(diagnostics, file_name, item)
+  for _, span in ipairs(item.spans) do
+    if span.file_name == file_name then
+      local message = item.message
+      if span.suggested_replacement ~= vim.NIL then
+        message = message .. "\nSuggested replacement:\n\n" .. tostring(span.suggested_replacement)
+      end
+
+      table.insert(diagnostics, {
+        lnum = span.line_start - 1,
+        end_lnum = span.line_end - 1,
+        col = span.column_start - 1,
+        end_col = span.column_end - 1,
+        severity = severities[item.level],
+        source = "clippy",
+        message = message
+      })
+    end
+  end
+
+  for _, child in ipairs(item.children) do
+    parse(diagnostics, file_name, child)
+  end
+end
+
+return {
+  cmd = "cargo",
+  args = { "clippy", "--message-format=json" },
+  stdin = false,
+  append_fname = false,
+  parser = function(output, bufnr)
+    local diagnostics = {}
+    local items = #output > 0 and vim.split(output, "\n") or {}
+    local file_name = vim.api.nvim_buf_get_name(bufnr)
+
+    for _, i in ipairs(items) do
+      local item = i ~= "" and vim.json.decode(i) or {}
+      -- cargo also outputs build artifacts messages in addition to diagnostics
+      if item and item.reason == "compiler-message" then
+        parse(diagnostics, file_name, item.message)
+      end
+    end
+    return diagnostics
+  end,
+}

--- a/lua/lint/linters/clippy.lua
+++ b/lua/lint/linters/clippy.lua
@@ -38,6 +38,7 @@ return {
     local diagnostics = {}
     local items = #output > 0 and vim.split(output, "\n") or {}
     local file_name = vim.api.nvim_buf_get_name(bufnr)
+    file_name = vim.fn.fnamemodify(file_name, ":.")
 
     for _, i in ipairs(items) do
       local item = i ~= "" and vim.json.decode(i) or {}

--- a/lua/lint/linters/codespell.lua
+++ b/lua/lint/linters/codespell.lua
@@ -1,15 +1,35 @@
 -- stdout output in the form "63: resourcs ==> resources, resource"
+local api = vim.api
 local pattern = "(%d+): (.*)"
 local groups = { "lnum", "message" }
 local severities = nil -- none provided
-
+local parser = require('lint.parser').from_pattern(pattern, groups, severities, {
+  source = 'codespell',
+  severity = vim.diagnostic.severity.INFO,
+})
 return {
   cmd = 'codespell',
   args = { '--stdin-single-line', "-" },
   stdin = true,
   ignore_exitcode = true,
-  parser = require('lint.parser').from_pattern(pattern, groups, severities, {
-    source = 'codespell',
-    severity = vim.diagnostic.severity.INFO,
-  }),
+  parser = function(output, bufnr, cwd)
+    local result = parser(output, bufnr, cwd)
+    for _, d in ipairs(result) do
+      local start, _, capture = d.message:find("(.*) ==>")
+      if start then
+        -- lenient - lint is async and buffer can change between lint start and result parsing
+        local ok, lines = pcall(api.nvim_buf_get_lines, bufnr, d.lnum, d.lnum + 1, true)
+        if ok then
+          local line = lines[1] or ""
+          local end_
+          start, end_ = line:find(vim.pesc(capture))
+          if start then
+            d.col = start - 1
+            d.end_col = end_
+          end
+        end
+      end
+    end
+    return result
+  end,
 }

--- a/lua/lint/linters/credo.lua
+++ b/lua/lint/linters/credo.lua
@@ -1,10 +1,18 @@
-local errorfmt = '[%t] %. stdin:%l:%c %m, [%t] %. stdin:%l %m'
+local pattern = "%[%a%]%s+(.+)%s+([^:]+):(%d+):?(%d*)%s+(.*)"
+local groups = { "severity", "file", "lnum", "col", "message" }
+local severity = {
+  ["↑"] = vim.diagnostic.severity.ERROR,
+  ["↗"] = vim.diagnostic.severity.WARN,
+  ["→"] = vim.diagnostic.severity.INFO,
+  ["↘"] = vim.diagnostic.severity.HINT,
+  ["↓"] = vim.diagnostic.severity.HINT,
+}
 
 return {
-  cmd = 'mix',
-  stdin = true,
-  args = { 'credo', 'list', '--format=oneline', '--read-from-stdin', '--strict'},
-  stream = 'stdout',
+  cmd = "mix",
+  stdin = false,
+  args = { "credo", "list", "--format=oneline", "--strict" },
+  stream = "stdout",
   ignore_exitcode = true, -- credo only returns 0 if there are no errors
-  parser = require('lint.parser').from_errorformat(errorfmt, { ['source'] = 'credo' })
+  parser = require("lint.parser").from_pattern(pattern, groups, severity, { ["source"] = "credo" }),
 }

--- a/lua/lint/linters/cspell.lua
+++ b/lua/lint/linters/cspell.lua
@@ -20,7 +20,7 @@ return {
         local lnum = math.max(0, item.lnum - 1)
         local col = math.max(0, item.col - 1)
         local end_lnum = item.end_lnum > 0 and (item.end_lnum - 1) or lnum
-        local end_col = col + word:len() - 2 or col
+        local end_col = col + vim.fn.strdisplaywidth(word) - 2 or col
         local diagnostic = {
           lnum = lnum,
           col = col,

--- a/lua/lint/linters/eugene.lua
+++ b/lua/lint/linters/eugene.lua
@@ -1,0 +1,26 @@
+return {
+  cmd = 'eugene',
+  args = {
+    'lint',
+    '--format=json',
+  },
+  stdin = false,
+  parser = function(output, _)
+    local diagnostics = {}
+    if #output > 0 then
+      local decoded = vim.json.decode(output)
+      for _, stmt in ipairs(decoded.statements) do
+        for _, tr in ipairs(stmt.triggered_rules) do
+          table.insert(diagnostics, {
+            source = 'eugene',
+            lnum = stmt.line_number,
+            col = 0,
+            severity = vim.diagnostic.severity.ERROR,
+            message = string.format('%s: %s: %s', tr.id, tr.name, tr.url),
+          })
+        end
+      end
+    end
+    return diagnostics
+  end,
+}

--- a/lua/lint/linters/hledger.lua
+++ b/lua/lint/linters/hledger.lua
@@ -1,0 +1,24 @@
+return {
+  cmd = "hledger",
+  stdin = true,
+  args = {"check", "-s", "-f", "-"},
+  stream = "stderr",
+  ignore_exitcode = true,
+  parser = function(output)
+    --- hledger currently outputs at most one error.
+    ---@type vim.Diagnostic[]
+    local result = {}
+    local pattern = "hledger: Error: %-:(%d+):(.*)"
+    local lnum, msg = output:match(pattern)
+    if lnum and (tonumber(lnum) or 0) > 0 then
+      table.insert(result, {
+        message = msg,
+        col = 0,
+        lnum = tonumber(lnum) - 1,
+        severity = vim.diagnostic.severity.ERROR,
+        source = "hledger"
+      })
+    end
+    return result
+  end
+}

--- a/lua/lint/linters/hledger.lua
+++ b/lua/lint/linters/hledger.lua
@@ -8,13 +8,16 @@ return {
     --- hledger currently outputs at most one error.
     ---@type vim.Diagnostic[]
     local result = {}
-    local pattern = "hledger: Error: %-:(%d+):(.*)"
-    local lnum, msg = output:match(pattern)
-    if lnum and (tonumber(lnum) or 0) > 0 then
+    local pattern = "hledger: Error: %-:(%d+)(%-?(%d*)):(.*)"
+    local lnum, _, end_lnum, msg = output:match(pattern)
+    lnum = tonumber(lnum)
+    end_lnum = tonumber(end_lnum)
+    if (lnum or 0) > 0 then
       table.insert(result, {
         message = msg,
         col = 0,
-        lnum = tonumber(lnum) - 1,
+        lnum = lnum - 1,
+        end_lnum = end_lnum and (end_lnum - 1) or nil,
         severity = vim.diagnostic.severity.ERROR,
         source = "hledger"
       })

--- a/lua/lint/linters/ksh.lua
+++ b/lua/lint/linters/ksh.lua
@@ -1,0 +1,12 @@
+return {
+  cmd = "ksh",
+  stdin = true,
+  append_fname = false,
+  args = { "-o", "noexec", "-s" },
+  stream = "stderr",
+  ignore_exitcode = true,
+  parser = require("lint.parser").from_errorformat(
+    "ksh:\\ syntax\\ %t%.%#\\ at\\ line\\ %l:\\ %m,ksh:\\ %t%.%#\\ line\\ %l:\\ %m",
+    { source = "ksh" }
+  ),
+}

--- a/lua/lint/linters/luac.lua
+++ b/lua/lint/linters/luac.lua
@@ -1,0 +1,12 @@
+return {
+  cmd = "luac",
+  stdin = true,
+  append_fname = false,
+  args = { "-p", "-" },
+  stream = "stderr",
+  ignore_exitcode = true,
+  parser = require("lint.parser").from_errorformat("luac:\\ stdin:%l:\\ %m,%-G%.%#", {
+    source = "luac",
+    severity = vim.diagnostic.severity.ERROR,
+  }),
+}

--- a/lua/lint/linters/markdownlint.lua
+++ b/lua/lint/linters/markdownlint.lua
@@ -1,11 +1,13 @@
-local efm = '%f:%l:%c %m,%f:%l %m'
-local is_windows = vim.loop.os_uname().version:match('Windows')
+local efm = "stdin:%l:%c %m,stdin:%l %m"
+local is_windows = vim.loop.os_uname().version:match("Windows")
 return {
-    cmd = is_windows and 'markdownlint.cmd' or 'markdownlint',
-    ignore_exitcode = true,
-    stream = 'stderr',
-    parser =  require('lint.parser').from_errorformat(efm, {
-        source = 'markdownlint',
-        severity = vim.diagnostic.severity.WARN,
-    })
+  cmd = is_windows and "markdownlint.cmd" or "markdownlint",
+  stdin = true,
+  args = { "--stdin" },
+  ignore_exitcode = true,
+  stream = "stderr",
+  parser = require("lint.parser").from_errorformat(efm, {
+    source = "markdownlint",
+    severity = vim.diagnostic.severity.WARN,
+  }),
 }

--- a/lua/lint/linters/mypy.lua
+++ b/lua/lint/linters/mypy.lua
@@ -19,6 +19,10 @@ return {
     '--no-color-output',
     '--no-error-summary',
     '--no-pretty',
+    '--python-executable',
+    function()
+      return vim.fn.exepath 'python3' or vim.fn.exepath 'python'
+    end
   },
   parser = require('lint.parser').from_pattern(
     pattern,

--- a/lua/lint/linters/phpinsights.lua
+++ b/lua/lint/linters/phpinsights.lua
@@ -25,9 +25,9 @@ return {
     for insight, severity in pairs(insight_to_severity) do
       for _, message in ipairs(json[insight] or {}) do
           table.insert(diagnostics, {
-            lnum = message.line - 1,
+            lnum = (message.line or 1) - 1,
             col = 0,
-            message = message.message,
+            message = message.message or message.title,
             severity = severity,
             source = bin,
           })

--- a/lua/lint/linters/pylint.lua
+++ b/lua/lint/linters/pylint.lua
@@ -9,11 +9,17 @@ local severities = {
 
 return {
   cmd = 'pylint',
-  stdin = false,
+  stdin = true,
   args = {
-    '-f', 'json'
+    '-f',
+    'json',
+    '--from-stdin',
+    function()
+      return vim.api.nvim_buf_get_name(0)
+    end,
   },
   ignore_exitcode = true,
+  stream = 'stdout',
   parser = function(output, bufnr)
     if output == "" then return {} end
     local diagnostics = {}

--- a/lua/lint/linters/revive.lua
+++ b/lua/lint/linters/revive.lua
@@ -1,12 +1,43 @@
--- path/to/file:line:col: code message
-local pattern = '[^:]+:(%d+):(%d+): (.*)'
-local groups = { 'lnum', 'col', 'message' }
-
 return {
-  cmd = 'revive',
+  cmd = "revive",
   stdin = false,
-  args = {},
-  parser = require('lint.parser').from_pattern(pattern, groups, nil, {
-    ['source'] = 'revive',
-  }),
+  args = { "-formatter", "json" },
+  parser = function(output, _)
+    local severities = {
+      error = vim.diagnostic.severity.ERROR,
+      warning = vim.diagnostic.severity.WARN,
+    }
+
+    local items = {}
+
+    -- revive returns "null" as a string if no errors/warnings were found
+    if output == "" or output == "null" then
+      return items
+    end
+
+    local decoded = vim.json.decode(output)
+    -- ensure we got valid json
+    if type(decoded) ~= "table" then
+      return items
+    end
+
+    local bufpath = vim.fn.expand("%:p")
+
+    for _, diag in ipairs(decoded) do
+      if diag.Position.Start.Filename == bufpath then
+        table.insert(items, {
+          source = "revive",
+          lnum = diag.Position.Start.Line - 1,
+          col = diag.Position.Start.Column - 1,
+          end_lnum = diag.Position.End.Line - 1,
+          end_col = diag.Position.End.Column - 1,
+          message = diag.Failure,
+          code = diag.RuleName,
+          severity = assert(severities[diag.Severity], "missing mapping for severity " .. diag.Severity),
+        })
+      end
+    end
+
+    return items
+  end,
 }

--- a/lua/lint/linters/slang.lua
+++ b/lua/lint/linters/slang.lua
@@ -1,0 +1,19 @@
+local pattern = "^([^:]+):(%d+):(%d+): (%w+): (.+)"
+
+local groups = { "file", "lnum", "col", "severity", "message" }
+
+local severities = {
+  ["error"] = vim.diagnostic.severity.ERROR,
+  ["warning"] = vim.diagnostic.severity.WARN,
+}
+
+return {
+  cmd = "slang",
+  stdin = false,
+  stream = "stderr",
+  args = {
+    "-Weverything",
+  },
+  ignore_exitcode = true,
+  parser = require("lint.parser").from_pattern(pattern, groups, severities, { ["source"] = "slang" }),
+}

--- a/lua/lint/linters/snakemake.lua
+++ b/lua/lint/linters/snakemake.lua
@@ -1,0 +1,79 @@
+return {
+  name = "snakemake",
+  cmd = "snakemake",
+  stdin = false,
+  append_fname = true,
+  args = { "--lint", "text", "--snakefile" },
+  stream = "stderr",
+  ignore_exitcode = true,
+  env = nil,
+  parser = function(lint_output, _)
+    local diagnostics = {}
+    local current_diagnostic
+
+    if string.find(lint_output, "Lints for") then
+      for lint_type, lines in lint_output:gmatch("Lints for (%a+) (.-)\n\n\n?") do
+        if lint_type == "rule" then
+          local linenum = lines:match("line (%d+),")
+          lines = string.gsub(lines, "\n", "")
+          -- rule-specific lints
+          -- display all at start of rule
+          for errmessage in lines:gmatch("%*% (.-):") do
+            if errmessage then
+              current_diagnostic = {
+                lnum = tonumber(linenum) - 1,
+                col = 0,
+                message = errmessage,
+                source = "snakemake",
+                severity = vim.diagnostic.severity.HINT,
+              }
+              table.insert(diagnostics, current_diagnostic)
+            end
+          end
+        elseif lint_type == "snakefile" then
+          -- general Snakefile lints related to the whole file
+          -- display all at start of file
+          for errmessage in lines:gmatch("%* ([^%d]-):") do
+            current_diagnostic = {
+              lnum = 0,
+              col = 0,
+              message = errmessage,
+              source = "snakemake",
+              severity = vim.diagnostic.severity.HINT,
+            }
+            table.insert(diagnostics, current_diagnostic)
+          end
+          -- general Snakefile lints related to specific lines
+          -- display each at its line
+          for errmessage, linenum in lines:gmatch("%* ([^\n]-) in line (%d+):") do
+            current_diagnostic = {
+              lnum = tonumber(linenum) - 1,
+              col = 0,
+              message = errmessage,
+              source = "snakemake",
+              severity = vim.diagnostic.severity.HINT,
+            }
+            table.insert(diagnostics, current_diagnostic)
+          end
+        end
+      end
+    elseif not string.find(lint_output, "Congratulations") then
+      -- error encountered while linting
+      -- display error type and message at reported line
+      local error, linenum, errmessage = string.match(lint_output, "(.*) in file .*, line (%d+):\n(.*)\n .*")
+      if error and errmessage then
+        errmessage = error .. ": " .. errmessage
+        current_diagnostic = {
+          lnum = tonumber(linenum) - 1,
+          col = 0,
+          message = errmessage,
+          source = "snakemake",
+          severity = vim.diagnostic.severity.ERROR,
+        }
+        table.insert(diagnostics, current_diagnostic)
+      end
+    end
+
+    return diagnostics
+  end,
+}

--- a/lua/lint/linters/sqlfluff.lua
+++ b/lua/lint/linters/sqlfluff.lua
@@ -33,11 +33,15 @@ return {
     local diagnostics = {}
     for _, i_filepath in ipairs(per_filepath) do
         for _, violation in ipairs(i_filepath.violations) do
+          local severity = vim.diagnostic.severity.WARN
+          if violation.code == "PRS" then
+            severity = vim.diagnostic.severity.ERROR
+          end
           table.insert(diagnostics, {
             source = 'sqlfluff',
             lnum = (violation.line_no or violation.start_line_no) - 1,
             col = (violation.line_pos or violation.start_line_pos) - 1,
-            severity = vim.diagnostic.severity.ERROR,
+            severity = severity,
             message = violation.description,
             user_data = {lsp = {code = violation.code}},
           })

--- a/lua/lint/linters/svlint.lua
+++ b/lua/lint/linters/svlint.lua
@@ -1,0 +1,17 @@
+local pattern = ".*(Fail)......([^:]+):(%d+):(%d+).*hint: (.+)%."
+local groups = { "severity", "file", "lnum", "col", "message" }
+
+local severities = {
+  ["Fail"] = vim.diagnostic.severity.WARN,
+}
+
+return {
+  cmd = "svlint",
+  stdin = false,
+  stream = "stdout",
+  args = {
+    "--oneline",
+  },
+  ignore_exitcode = true,
+  parser = require("lint.parser").from_pattern(pattern, groups, severities, { ["source"] = "svlint" }),
+}

--- a/lua/lint/linters/systemd-analyze.lua
+++ b/lua/lint/linters/systemd-analyze.lua
@@ -1,0 +1,11 @@
+return {
+  cmd = "systemd-analyze",
+  args = {"verify"},
+  ignore_exitcode = true,
+  stdin = false,
+  stream = "stderr",
+  parser = require("lint.parser").from_errorformat("%f:%l:%m", {
+    source = "systemd",
+    severity = vim.diagnostic.severity.WARN
+  })
+}

--- a/lua/lint/linters/tidy.lua
+++ b/lua/lint/linters/tidy.lua
@@ -17,6 +17,7 @@ return {
   cmd = 'tidy',
   stdin = true,
   stream = 'stderr',
+  ignore_exitcode = true,
   args = {
     '-quiet',
     '-errors',

--- a/lua/lint/linters/verilator.lua
+++ b/lua/lint/linters/verilator.lua
@@ -1,6 +1,6 @@
-local pattern = "^%%(.-)-?(%u*): .-:(%d+):(%d+): (.*)"
+local pattern = "^%%(.-)-?(%u*): (.-):(%d+):(%d+): (.*)"
 
-local groups = { "severity", "code", "lnum", "col", "message" }
+local groups = { "severity", "code", "file", "lnum", "col", "message" }
 
 local severities = {
   ["Error"] = vim.diagnostic.severity.ERROR,

--- a/lua/lint/linters/yq.lua
+++ b/lua/lint/linters/yq.lua
@@ -1,0 +1,10 @@
+return {
+  cmd = "yq",
+  stdin = true,
+  stream = "stderr",
+  ignore_exitcode = true,
+  parser = require("lint.parser").from_pattern("line (%d+): (.+)", {
+    "lnum",
+    "message",
+  }, nil, { source = "yq" }),
+}

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -20,7 +20,7 @@ function M.from_errorformat(efm, skeleton)
     local lines = vim.split(output, '\n')
     local qflist = vim.fn.getqflist({ efm = efm, lines = lines })
     local result = {}
-    for _, item in pairs(qflist.items) do
+    for _, item in ipairs(qflist.items) do
       if item.valid == 1 and (bufnr == nil or item.bufnr == 0 or item.bufnr == bufnr) then
         local lnum = math.max(0, item.lnum - 1)
         local col = math.max(0, item.col - 1)
@@ -135,7 +135,9 @@ function M.from_pattern(pattern, groups, severity_map, defaults, opts)
     end
     local result = {}
     local buffer_path = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ":p")
-    for _, line in ipairs(vim.fn.split(output, '\n')) do
+    --- bwc for 0.6 requires boolean arg instead of table
+    ---@diagnostic disable-next-line: param-type-mismatch
+    for line in vim.gsplit(output, "\n", true) do
       local diagnostic = match(linter_cwd, buffer_path, line)
       if diagnostic then
         table.insert(result, diagnostic)

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -10,6 +10,9 @@ local severity_by_qftype = {
 
 -- Return a parse function that uses an errorformat to parse the output.
 -- See `:help errorformat`
+---@param efm string
+---@param skeleton table<string, any> | vim.Diagnostic
+---@return fun(output: string, bufnr: integer):lsp.Diagnostic[]
 function M.from_errorformat(efm, skeleton)
   skeleton = skeleton or {}
   skeleton.severity = skeleton.severity or vd.severity.ERROR
@@ -150,6 +153,11 @@ Output from linter:
 %s
 ]]
 
+
+--- Turn a parse function into a parser table
+---
+---@param parse fun(output: string, bufnr: integer, cwd: string):vim.Diagnostic[]
+---@return {on_chunk: fun(chunk: string), on_done: fun(publish: fun(diagnostics: vim.Diagnostic[], bufnr: integer), bufnr: integer, cwd: string)}
 function M.accumulate_chunks(parse)
   local chunks = {}
   return {

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -12,7 +12,7 @@ local severity_by_qftype = {
 -- See `:help errorformat`
 ---@param efm string
 ---@param skeleton table<string, any> | vim.Diagnostic
----@return fun(output: string, bufnr: integer):lsp.Diagnostic[]
+---@return lint.parse
 function M.from_errorformat(efm, skeleton)
   skeleton = skeleton or {}
   skeleton.severity = skeleton.severity or vd.severity.ERROR
@@ -54,7 +54,7 @@ local normalize = (vim.fs ~= nil and vim.fs.normalize ~= nil)
 ---@param severity_map? table<string, vim.diagnostic.Severity>
 ---@param defaults? table
 ---@param opts? {col_offset?: integer, end_col_offset?: integer, lnum_offset?: integer, end_lnum_offset?: integer}
----@return fun(output: string, bufnr: integer, cwd: string):lsp.Diagnostic[]
+---@return lint.parse
 function M.from_pattern(pattern, groups, severity_map, defaults, opts)
   defaults = defaults or {}
   severity_map = severity_map or {}
@@ -159,7 +159,7 @@ Output from linter:
 --- Turn a parse function into a parser table
 ---
 ---@param parse fun(output: string, bufnr: integer, cwd: string):vim.Diagnostic[]
----@return {on_chunk: fun(chunk: string), on_done: fun(publish: fun(diagnostics: vim.Diagnostic[], bufnr: integer), bufnr: integer, cwd: string)}
+---@return lint.Parser
 function M.accumulate_chunks(parse)
   local chunks = {}
   return {

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -1,3 +1,5 @@
+---@mod lint.parser Parsers and parse functions
+---
 local M = {}
 local vd = vim.diagnostic
 local api = vim.api
@@ -9,10 +11,9 @@ local severity_by_qftype = {
   N = vd.severity.HINT,
 }
 
--- Return a parse function that uses an errorformat to parse the output.
--- See `:help errorformat`
----@param efm string
----@param skeleton table<string, any> | vim.Diagnostic
+---Return a parse function that uses an errorformat to parse the output.
+---@param efm string Format following |errorformat|
+---@param skeleton table<string, any> | vim.Diagnostic default values
 ---@return lint.parse
 function M.from_errorformat(efm, skeleton)
   skeleton = skeleton or {}
@@ -48,7 +49,7 @@ local normalize = (vim.fs ~= nil and vim.fs.normalize ~= nil)
   or function(path) return path end
 
 
---- Parse a linter's output using a Lua pattern
+---Return a parse function that parses a linter's output using a Lua or LPEG pattern.
 ---
 ---@param pattern string|vim.lpeg.Pattern|fun(line: string):string[]
 ---@param groups string[]
@@ -201,6 +202,10 @@ function M.accumulate_chunks(parse)
 end
 
 
+---Split a parser into two
+---
+---@param parser lint.Parser
+---@return lint.Parser, lint.Parser
 function M.split(parser)
   local remaining_calls = 2
   local chunks1 = {}

--- a/lua/lint/parser.lua
+++ b/lua/lint/parser.lua
@@ -51,6 +51,7 @@ local normalize = (vim.fs ~= nil and vim.fs.normalize ~= nil)
 ---@param severity_map? table<string, vim.diagnostic.Severity>
 ---@param defaults? table
 ---@param opts? {col_offset?: integer, end_col_offset?: integer, lnum_offset?: integer, end_lnum_offset?: integer}
+---@return fun(output: string, bufnr: integer, cwd: string):lsp.Diagnostic[]
 function M.from_pattern(pattern, groups, severity_map, defaults, opts)
   defaults = defaults or {}
   severity_map = severity_map or {}

--- a/tests/codespell_spec.lua
+++ b/tests/codespell_spec.lua
@@ -1,0 +1,21 @@
+local api = vim.api
+describe("codespell", function()
+  it("provides end_col", function()
+    local parser = require("lint.linters.codespell").parser
+    local bufnr = api.nvim_create_buf(false, true)
+    api.nvim_buf_set_lines(bufnr, 0, -1, true, {'  error("hello crate test")'})
+    local result = parser("1: crate ==> create", bufnr)
+    local expected = {
+      {
+        col = 15,
+        end_col = 20,
+        end_lnum = 0,
+        lnum = 0,
+        message = 'crate ==> create',
+        severity = vim.diagnostic.severity.INFO,
+        source = 'codespell',
+      }
+    }
+    assert.are.same(expected, result)
+  end)
+end)

--- a/tests/credo_spec.lua
+++ b/tests/credo_spec.lua
@@ -1,13 +1,14 @@
-describe('linter.credo', function()
-  it('can parse the output', function()
-    local parser = require('lint.linters.credo').parser
+describe("linter.credo", function()
+  it("can parse the output", function()
+    local parser = require("lint.linters.credo").parser
+    local bufnr = vim.uri_to_bufnr("file:///foo.ex")
     -- taken from example screenshot from credo's documentation https://hexdocs.pm/credo/overview.html
     -- 3rd record shouldn't get picked up because there is no file/line information
-    local result = parser([[
-[R] → stdin:1:11 Unless conditions should avoid having an `else` block.
-[W] ↗ stdin:9:5 Use `reraise` inside a rescue block to preserve the original stacktrace.
+    local result = parser( [[
+[R] → /foo.ex:1:11 Unless conditions should avoid having an `else` block.
+[W] ↗ /foo.ex:9:5 Use `reraise` inside a rescue block to preserve the original stacktrace.
 [W] ↗ Exception modules should be named consistently. It seems your strategy is to have `Error` ....
-]])
+]], bufnr)
     assert.are.same(2, #result)
 
     local expected_error = {
@@ -15,9 +16,9 @@ describe('linter.credo', function()
       end_col = 10,
       lnum = 0,
       end_lnum = 0,
-      severity = 1,
-      message = 'Unless conditions should avoid having an `else` block.',
-      source = 'credo',
+      severity = 3,
+      message = "Unless conditions should avoid having an `else` block.",
+      source = "credo",
     }
 
     assert.are.same(expected_error, result[1])
@@ -28,8 +29,8 @@ describe('linter.credo', function()
       lnum = 8,
       end_lnum = 8,
       severity = 2,
-      message = 'Use `reraise` inside a rescue block to preserve the original stacktrace.',
-      source = 'credo',
+      message = "Use `reraise` inside a rescue block to preserve the original stacktrace.",
+      source = "credo",
     }
 
     assert.are.same(expected_error, result[2])

--- a/tests/hledger_spec.lua
+++ b/tests/hledger_spec.lua
@@ -32,4 +32,28 @@ account assets:receivable:customer    ; type:A  ; (L,E,R,X,C,V)
     }
     assert.are.same(expected, parser(output))
   end)
+  it("supports column-ranges", function()
+    -- editorconfig-checker-disable
+    local msg = [[
+109 | 2024-08-16 assert balance
+    |     assets:checking           4 EUR = 68,59 EUR
+
+This transaction is unbalanced.
+The real postings' sum should be 0 but is: 4 EUR
+Consider adjusting this entry's amounts, or adding missing postings.
+]]
+    -- editorconfig-checker-enable
+    local output = "hledger: Error: -:109-110:" .. msg
+    local expected = {
+      {
+        message = msg,
+        col = 0,
+        lnum = 108,
+        end_lnum = 109,
+        severity = vim.diagnostic.severity.ERROR,
+        source = "hledger"
+      },
+    }
+    assert.are.same(expected, parser(output))
+  end)
 end)

--- a/tests/hledger_spec.lua
+++ b/tests/hledger_spec.lua
@@ -1,0 +1,35 @@
+describe("hledger", function()
+  local parser = require("lint.linters.hledger").parser
+  it("no diagnostics on empty output", function()
+    assert.are.same({}, parser(""))
+  end)
+
+  it("returns error diagnostic on error output", function()
+    -- editorconfig-checker-disable
+    local msg = [[
+   | 2024-08-10 * payment
+   |     revenue:dev:customer          -1.234,00 EUR
+14 |     assets:receivable:customer     1.234,00 EUR
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Strict account checking is enabled, and
+account "assets:receivable:customer" has not been declared.
+Consider adding an account directive. Examples:
+
+account assets:receivable:customer
+account assets:receivable:customer    ; type:A  ; (L,E,R,X,C,V)
+]]
+    -- editorconfig-checker-enable
+    local output = "hledger: Error: -:14:" .. msg
+    local expected = {
+      {
+        message = msg,
+        col = 0,
+        lnum = 13,
+        severity = vim.diagnostic.severity.ERROR,
+        source = "hledger"
+      },
+    }
+    assert.are.same(expected, parser(output))
+  end)
+end)

--- a/tests/markdownlint_spec.lua
+++ b/tests/markdownlint_spec.lua
@@ -1,33 +1,33 @@
-describe('linter.markdownlint', function()
-  it('can parse the output', function()
-    local parser = require('lint.linters.markdownlint').parser
+describe("linter.markdownlint", function()
+  it("can parse the output", function()
+    local parser = require("lint.linters.markdownlint").parser
     local result = parser([[
-README.md:35 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## What's in this repo?"]
-README.md:36 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- `dotfiles`"]
-README.md:47:81 MD013/line-length Line length [Expected: 80; Actual: 114]
-README.md:55:81 MD013/line-length Line length [Expected: 80; Actual: 244]
+stdin:35 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## What's in this repo?"]
+stdin:36 MD032/blanks-around-lists Lists should be surrounded by blank lines [Context: "- `dotfiles`"]
+stdin:47:81 MD013/line-length Line length [Expected: 80; Actual: 114]
+stdin:55:81 MD013/line-length Line length [Expected: 80; Actual: 244]
 ]])
-  assert.are.same(4, #result)
-  local expected = {
-    source = 'markdownlint',
-    message = 'MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## What\'s in this repo?"]',
-    lnum = 34,
-    col = 0,
-    end_lnum = 34,
-    end_col = 0,
-    severity = vim.diagnostic.severity.WARN,
-  }
-  assert.are.same(expected, result[1])
+    assert.are.same(4, #result)
+    local expected = {
+      source = "markdownlint",
+      message = 'MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## What\'s in this repo?"]',
+      lnum = 34,
+      col = 0,
+      end_lnum = 34,
+      end_col = 0,
+      severity = vim.diagnostic.severity.WARN,
+    }
+    assert.are.same(expected, result[1])
 
-  expected = {
-    source = 'markdownlint',
-    message = 'MD013/line-length Line length [Expected: 80; Actual: 114]',
-    lnum = 46,
-    col = 80,
-    end_lnum = 46,
-    end_col = 80,
-    severity = vim.diagnostic.severity.WARN,
-  }
-  assert.are.same(expected, result[3])
+    expected = {
+      source = "markdownlint",
+      message = "MD013/line-length Line length [Expected: 80; Actual: 114]",
+      lnum = 46,
+      col = 80,
+      end_lnum = 46,
+      end_col = 80,
+      severity = vim.diagnostic.severity.WARN,
+    }
+    assert.are.same(expected, result[3])
   end)
 end)

--- a/tests/parser_spec.lua
+++ b/tests/parser_spec.lua
@@ -73,4 +73,58 @@ bar:209:14 Bigger mistake
     }
     assert.are.same(expected, result)
   end)
+
+  it("supports lpeg pattern", function()
+    if not vim.re then
+      return
+    end
+    local pattern = vim.re.compile("{[0-9]+} ':' { (.*) }")
+    local groups = { 'lnum', 'message' }
+    local parser = require('lint.parser').from_pattern(pattern, groups)
+    local output = [[
+10:Big mistake
+14:Bigger mistake
+]]
+    local result = parser(output, 0)
+    local expected = {
+      {
+        message = 'Big mistake',
+        lnum = 9,
+        end_lnum = 9,
+        col = 0,
+        end_col = 0,
+        severity = vim.diagnostic.severity.ERROR,
+      },
+      {
+        message = 'Bigger mistake',
+        lnum = 13,
+        col = 0,
+        end_lnum = 13,
+        end_col = 0,
+        severity = vim.diagnostic.severity.ERROR,
+      },
+    }
+    assert.are.same(expected, result)
+    assert.are.same({}, parser("no-match", 0))
+  end)
+
+  it("supports match function", function()
+    local pattern = function(_)
+      return { 10, "hello" }
+    end
+    local groups = { 'lnum', 'message' }
+    local parser = require('lint.parser').from_pattern(pattern, groups)
+    local result = parser("foo", 0)
+    local expected = {
+      {
+        message = "hello",
+        lnum = 9,
+        col = 0,
+        end_lnum = 9,
+        end_col = 0,
+        severity = vim.diagnostic.severity.ERROR
+      },
+    }
+    assert.are.same(expected, result)
+  end)
 end)

--- a/tests/snakemake_spec.lua
+++ b/tests/snakemake_spec.lua
@@ -1,0 +1,101 @@
+describe("linter.snakemake", function()
+  it("can parse linter output", function()
+    local parser = require("lint.linters.snakemake").parser
+    local bufnr = vim.uri_to_bufnr("file://Snakefile")
+    local output = [[
+Lints for snakefile Snakefile:
+    * Absolute path "/absolute/path/to/file" in line 17:
+      Do not define absolute paths inside of the workflow, since this renders your workflow
+      irreproducible on other machines. Use path relative to the working directory instead, or
+      make the path configurable via a config file.
+      Also see:
+      https://snakemake.readthedocs.io/en/latest/snakefiles/configuration.html#configuration
+    * Mixed rules and functions in same snakefile.:
+      Small one-liner functions used only once should be defined as lambda expressions. Other
+      functions should be collected in a common module, e.g. 'rules/common.smk'. This makes
+      the workflow steps more readable.
+      Also see:
+      https://snakemake.readthedocs.io/en/latest/snakefiles/modularization.html#includes
+
+Lints for rule rule1 (line 15, Snakefile):
+    * Specify a conda environment or container for each rule.:
+      This way, the used software for each specific step is documented, and the workflow can
+      be executed on any machine without prerequisites.
+      Also see:
+      https://snakemake.readthedocs.io/en/latest/snakefiles/deployment.html#integrated-package-management
+      https://snakemake.readthedocs.io/en/latest/snakefiles/deployment.html#running-jobs-in-containers
+    * Shell command directly uses variable foo from outside of the rule:
+      It is recommended to pass all files as input and output, and non-file parameters via the
+      params directive. Otherwise, provenance tracking is less accurate.
+      Also see:
+      https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#non-file-parameters-for-rules
+
+]]
+    local result = parser(output, bufnr)
+
+    assert.are.same(4, #result)
+
+    local expected_hint_1 = {
+      lnum = 0,
+      col = 0,
+      message = "Mixed rules and functions in same snakefile.",
+      severity = vim.diagnostic.severity.HINT,
+      source = "snakemake",
+    }
+
+    assert.are.same(expected_hint_1, result[1])
+
+    local expected_hint_2 = {
+      lnum = 16,
+      col = 0,
+      message = 'Absolute path "/absolute/path/to/file"',
+      severity = vim.diagnostic.severity.HINT,
+      source = "snakemake",
+    }
+
+    assert.are.same(expected_hint_2, result[2])
+
+    local expected_hint_3 = {
+      lnum = 14,
+      col = 0,
+      message = "Specify a conda environment or container for each rule.",
+      severity = vim.diagnostic.severity.HINT,
+      source = "snakemake",
+    }
+
+    assert.are.same(expected_hint_3, result[3])
+
+    local expected_hint_4 = {
+      lnum = 14,
+      col = 0,
+      message = "Shell command directly uses variable foo from outside of the rule",
+      severity = vim.diagnostic.severity.HINT,
+      source = "snakemake",
+    }
+
+    assert.are.same(expected_hint_4, result[4])
+  end)
+
+  it("can parse error output", function()
+    local parser = require("lint.linters.snakemake").parser
+    local bufnr = vim.uri_to_bufnr("file:///Snakefile")
+    local output = [[
+KeyError in file Snakefile, line 5:
+'nonexistent_key'
+  File "Snakefile", line 5, in <module>
+]]
+    local result = parser(output, bufnr)
+
+    assert.are.same(1, #result)
+
+    local expected_error = {
+      lnum = 4,
+      col = 0,
+      message = "KeyError: 'nonexistent_key'",
+      severity = vim.diagnostic.severity.ERROR,
+      source = "snakemake",
+    }
+
+    assert.are.same(expected_error, result[1])
+  end)
+end)

--- a/tests/sqlfluff_spec.lua
+++ b/tests/sqlfluff_spec.lua
@@ -3,6 +3,7 @@ describe('linter.sqlfluff', function()
     local parser = require('lint.linters.sqlfluff').parser
     local bufnr = vim.uri_to_bufnr('file:///non-existent.sql')
     -- actual output I got from running sqlfluff
+    -- NB: These tests do not address parsing failures
     local result = parser([[
 [{"filepath": "stdin", "violations": [{"start_line_no": 68, "start_line_pos": 1, "code": "L003", "description": "Expected 1 indentation, found 0 [compared to line 52]"}, {"start_line_no": 68, "start_line_pos": 1, "code": "L013", "description": "Column expression without alias. Use explicit `AS` clause."}]}]
 
@@ -15,7 +16,7 @@ describe('linter.sqlfluff', function()
       message = 'Expected 1 indentation, found 0 [compared to line 52]',
       lnum = 67, -- mind the line indexing
       col = 0, -- mind the column indexing
-      severity = vim.diagnostic.severity.ERROR,
+      severity = vim.diagnostic.severity.WARN,
       user_data = {lsp = {code = 'L003'}},
     }
     assert.are.same(expected[1], result[1])
@@ -25,7 +26,7 @@ describe('linter.sqlfluff', function()
       message = 'Column expression without alias. Use explicit `AS` clause.',
       lnum = 67,
       col = 0,
-      severity = vim.diagnostic.severity.ERROR,
+      severity = vim.diagnostic.severity.WARN,
       user_data = {lsp = {code = 'L013'}},
     }
     assert.are.same(expected[2], result[2])
@@ -47,7 +48,7 @@ describe('linter.sqlfluff', function()
       message = 'Expected 1 indentation, found 0 [compared to line 52]',
       lnum = 67, -- mind the line indexing
       col = 0, -- mind the column indexing
-      severity = vim.diagnostic.severity.ERROR,
+      severity = vim.diagnostic.severity.WARN,
       user_data = {lsp = {code = 'L003'}},
     }
     assert.are.same(expected[1], result[1])
@@ -57,7 +58,7 @@ describe('linter.sqlfluff', function()
       message = 'Column expression without alias. Use explicit `AS` clause.',
       lnum = 67,
       col = 0,
-      severity = vim.diagnostic.severity.ERROR,
+      severity = vim.diagnostic.severity.WARN,
       user_data = {lsp = {code = 'L013'}},
     }
     assert.are.same(expected[2], result[2])

--- a/tests/verilator_spec.lua
+++ b/tests/verilator_spec.lua
@@ -1,6 +1,7 @@
 describe('linter.verilator', function()
   it('can parse the output', function()
     local parser = require('lint.linters.verilator').parser
+    local bufnr = vim.uri_to_bufnr('file:///t.v')
     local result = parser([[
 %Warning-DECLFILENAME: t.v:24:8: Filename 't' does not match MODULE name: 'uart'
     24 | module uart
@@ -30,7 +31,7 @@ describe('linter.verilator', function()
     64 |  uart_tx
       |  ^~~~~~~
 %Error: Exiting due to 3 error(s), 3 warning(s)
-    ]], vim.api.nvim_get_current_buf())
+    ]], bufnr, '')
     assert.are.same(6, #result)
 
     local expected = {
@@ -66,5 +67,5 @@ describe('linter.verilator', function()
       },
     }
     assert.are.same(expected, result[5])
-        end)
-      end)
+  end)
+end)


### PR DESCRIPTION
- **pylint: use stdin (#628)**
- **cspell: fix end_col if string contains unicode characters (#612)**
- **mypy: use python from the current environment (#627)**
- **Add eugene migration linter for postgres (#621)**
- **Add clippy (#626)**
- **clippy: Use relative path instead of absolute (#629)**
- **Add hledger**
- **Handle lnum range in hledger output**
- **Add systemd-analyze linter**
- **Add support for lpeg patterns and match functions to `from_pattern`**
- **tidy: Set ignore_exitcode**
- **codespell: Provide col/end_col information**
- **Add busted, luassert, lua to workspace library; add some type annotations**
- **Split output using vim.gsplit in from_pattern**
- **Use type alias and classes for some type annotations**
- **Prevent cmd.exe taking over tab title (#649)**
- **sqlfluff: report only parse errors as ERROR, everything else as WARNING (#642)**
- **Add awk linter (#653)**
- **Ensure parse functions run in the context of the original buffer**
- **revive: use JSON format to add proper severities (#645)**
- **credo: respect .credo.exs (#623)**
- **Add API docs generated using vimcats**
- **Fix duplicate doc tags**
- **phpinsights: Use fallback values if line or message is missing (#656)**
- **Add yq linter (#657)**
- **Fix format error in README example (#658)**
- **Add bash linter**
- **Add ksh linter**
- **Add luac linter**
- **Add snakemake linter (#659)**
- **markdownlint: use stdin (#664)**
- **Add slang linter (for systemverilog) (#667)**
- **Add svlint (#670)**
- **verilator: show only diagnostics for current buffer (#668)**
- **feat: allow linter's cwd to be specifed as function**
